### PR TITLE
Fix aircraft identification by registration

### DIFF
--- a/task.ts
+++ b/task.ts
@@ -634,8 +634,8 @@ export default class Task extends ETL {
             }
             
             // If not found by ICAO hex, try to find by registration
-            if (!include) {
-                include = includesMap.get(id);
+            if (!include && ac.r) {
+                include = includesMap.get(ac.r.toLowerCase().trim());
             }
             
             if (include) {


### PR DESCRIPTION
This PR fixes an issue where aircraft couldn't be matched by registration after
switching to ICAO hex as the primary identifier. The code was incorrectly using
the ICAO hex code as the lookup key when trying to match by registration.

Changes:
- Updated the registration lookup to use the aircraft's registration field (ac.r)
  instead of the ICAO hex code
- Ensures aircraft can be properly matched by both ICAO hex (primary) and
  registration (secondary)

This change maintains backward compatibility with existing aircraft configurations
that rely on registration-based identification.
